### PR TITLE
`seaport-js` SDK를 이용한 WBOA and AssetContractShared 토큰 거래

### DIFF
--- a/src/__tests__/boaspace/basic-fulfill.spec.ts
+++ b/src/__tests__/boaspace/basic-fulfill.spec.ts
@@ -6,7 +6,13 @@ import { parseEther } from "ethers/lib/utils";
 import { ethers, waffle } from "hardhat";
 import sinon from "sinon";
 import { ItemType, MAX_INT } from "../../constants";
-import { TestERC1155, TestERC721, AssetContractShared, SharedStorefrontLazyMintAdapter, SharedStorefrontLazyMintAdapter__factory } from "../../typechain";
+import {
+  TestERC1155,
+  TestERC721,
+  AssetContractShared,
+  SharedStorefrontLazyMintAdapter,
+  SharedStorefrontLazyMintAdapter__factory,
+} from "../../typechain";
 import { CreateOrderInput, CurrencyItem } from "../../types";
 import * as fulfill from "../../utils/fulfill";
 import { describeWithFixture } from "../utils/setup";
@@ -296,10 +302,7 @@ describeWithFixture(
         await secondApprovalAction.transactionMethods.transact();
 
         expect(
-          await testErc20.allowance(
-            fulfiller.address,
-            seaport.contract.address
-          )
+          await testErc20.allowance(fulfiller.address, seaport.contract.address)
         ).eq(MAX_INT);
 
         const thirdApprovalAction = actions[2];
@@ -573,10 +576,7 @@ describeWithFixture(
         await secondApprovalAction.transactionMethods.transact();
 
         expect(
-          await testErc20.allowance(
-            fulfiller.address,
-            seaport.contract.address
-          )
+          await testErc20.allowance(fulfiller.address, seaport.contract.address)
         ).eq(MAX_INT);
 
         const thirdApprovalAction = actions[2];
@@ -600,7 +600,9 @@ describeWithFixture(
         ).to.be.true;
 
         // approve to SharedStorefrontLazyMintAdapter
-        await assetToken.connect(fulfiller).setApprovalForAll(lazyMintAdapter.address, true);
+        await assetToken
+          .connect(fulfiller)
+          .setApprovalForAll(lazyMintAdapter.address, true);
 
         expect(
           await assetToken.isApprovedForAll(

--- a/src/__tests__/boaspace/erc1155-wboa.fulfill.spec.ts
+++ b/src/__tests__/boaspace/erc1155-wboa.fulfill.spec.ts
@@ -1,0 +1,250 @@
+import { providers } from "@0xsequence/multicall";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { parseEther } from "ethers/lib/utils";
+import { ethers, waffle } from "hardhat";
+import sinon from "sinon";
+import { ItemType, MAX_INT, OrderType } from "../../constants";
+import {
+  AssetContractShared,
+  SharedStorefrontLazyMintAdapter,
+  WBOA9,
+} from "../../typechain";
+import { CreateOrderInput, CurrencyItem } from "../../types";
+import * as fulfill from "../../utils/fulfill";
+import {
+  getBalancesForFulfillOrder,
+  verifyBalancesAfterFulfill,
+} from "../utils/balance";
+import { describeWithFixture } from "../utils/setup";
+import { createTokenId } from "../../utils/parseTokenId";
+
+describeWithFixture(
+  "Buying multiple listings or accepting multiple offers through SharedStorefrontLazyMintAdapter",
+  (fixture) => {
+    let offerer: SignerWithAddress;
+    let zone: SignerWithAddress;
+    let fulfiller: SignerWithAddress;
+    let admin: SignerWithAddress;
+    let multicallProvider: providers.MulticallProvider;
+    let standardCreateOrderInput: CreateOrderInput;
+    let fulfillStandardOrderSpy: sinon.SinonSpy;
+
+    let tokenId: BigNumber;
+    const assetTokenAmount = "10";
+
+    const OPENSEA_DOMAIN = "opensea.io";
+    const OPENSEA_TAG = "360c6ebe";
+
+    const ZeroAddress = "0x0000000000000000000000000000000000000000";
+
+    let assetToken: AssetContractShared;
+    let lazyMintAdapter: SharedStorefrontLazyMintAdapter;
+    let wboaToken: WBOA9;
+
+    beforeEach(async () => {
+      const { seaport } = fixture;
+
+      fulfillStandardOrderSpy = sinon.spy(fulfill, "fulfillStandardOrder");
+
+      [offerer, zone, fulfiller, admin] = await ethers.getSigners();
+      multicallProvider = new providers.MulticallProvider(ethers.provider);
+
+      // Deploy AssetContractShared contract
+      const name = "BOASPACE Collections";
+      const symbol = "BOASPACESTORE";
+      const templateURI = "";
+
+      const assetTokenFactory = await ethers.getContractFactory(
+        "AssetContractShared"
+      );
+      assetToken = (await assetTokenFactory
+        .connect(admin)
+        .deploy(
+          name,
+          symbol,
+          ethers.constants.AddressZero,
+          templateURI,
+          ethers.constants.AddressZero
+        )) as AssetContractShared;
+      await assetToken.deployed();
+      console.log("AssetContractShared:", assetToken.address);
+
+      // Deploy SharedStorefrontLazyMintAdapter contract
+      const lazyMintAdapterFactory = await ethers.getContractFactory(
+        "SharedStorefrontLazyMintAdapter"
+      );
+      lazyMintAdapter = (await lazyMintAdapterFactory
+        .connect(admin)
+        .deploy(
+          seaport.contract.address,
+          ZeroAddress,
+          assetToken.address
+        )) as SharedStorefrontLazyMintAdapter;
+      console.log("SharedStorefrontLazyMintAdapter:", lazyMintAdapter.address);
+
+      // Deploy WBOA9 contract
+      const wboa9Factory = await ethers.getContractFactory("WBOA9");
+      wboaToken = (await wboa9Factory.connect(admin).deploy()) as WBOA9;
+      console.log("WBOA9:", wboaToken.address);
+    });
+
+    afterEach(() => {
+      fulfillStandardOrderSpy.restore();
+    });
+
+    describe("[Accept offer] I want to accept a partial offer for my AssetContractShared", async () => {
+      beforeEach(async () => {
+        const { seaport } = fixture;
+        console.log("seaport:", seaport.contract.address);
+
+        // mint AssetContractShared
+        const creatorContract = assetToken.connect(fulfiller);
+        const tokenQuantity = 100;
+        const tokenIndex = BigNumber.from(1);
+        const data =
+          "https://ipfs.io/ipfs/QmXdYWxw3di8Uys9fmWTmdariUoUgBCsdVfHtseL2dtEP7";
+        const buffer = ethers.utils.toUtf8Bytes(data);
+
+        tokenId = createTokenId(fulfiller.address, tokenIndex, tokenQuantity);
+        console.log(
+          "Combined tokenId: %s (%s)",
+          tokenId.toString(),
+          tokenId.toHexString()
+        );
+        await creatorContract.mint(
+          fulfiller.address,
+          tokenId,
+          tokenQuantity,
+          buffer
+        );
+        console.log("Token minted to:", fulfiller.address);
+
+        console.log(
+          "fulfiller: ",
+          await assetToken.balanceOf(fulfiller.address, tokenId)
+        );
+
+        // Deposit BOA from offerer to WBOA
+        await wboaToken
+          .connect(offerer)
+          .deposit({ value: parseEther("20").toString() });
+
+        standardCreateOrderInput = {
+          allowPartialFills: true,
+
+          offer: [
+            {
+              amount: parseEther("10").toString(),
+              token: wboaToken.address,
+            },
+          ],
+          consideration: [
+            {
+              itemType: ItemType.ERC1155,
+              token: lazyMintAdapter.address,
+              amount: assetTokenAmount,
+              identifier: tokenId.toString(),
+              recipient: offerer.address,
+            },
+          ],
+          // 2.5% fee
+          fees: [{ recipient: zone.address, basisPoints: 250 }],
+        };
+      });
+
+      it("Offer: WBOA9(ERC20) <=> AssetContractShared", async () => {
+        const { seaport } = fixture;
+
+        const { executeAllActions } = await seaport.createOrder(
+          standardCreateOrderInput,
+          offerer.address
+        );
+
+        const order = await executeAllActions();
+
+        expect(order.parameters.orderType).eq(OrderType.PARTIAL_OPEN);
+
+        const orderStatus = await seaport.getOrderStatus(
+          seaport.getOrderHash(order.parameters)
+        );
+
+        const ownerToTokenToIdentifierBalances =
+          await getBalancesForFulfillOrder(
+            order,
+            fulfiller.address,
+            multicallProvider
+          );
+
+        const { actions } = await seaport.fulfillOrder({
+          order,
+          unitsToFill: 2,
+          accountAddress: fulfiller.address,
+          domain: OPENSEA_DOMAIN,
+        });
+
+        // approve to SharedStorefrontLazyMintAdapter
+        await assetToken
+          .connect(fulfiller)
+          .setApprovalForAll(lazyMintAdapter.address, true);
+        expect(
+          await assetToken.isApprovedForAll(
+            fulfiller.address,
+            lazyMintAdapter.address
+          )
+        ).to.be.true;
+
+        // We also need to approve ERC-20 as we send that out as fees..
+        const approvalAction = actions[0];
+        expect(approvalAction).to.deep.equal({
+          type: "approval",
+          token: wboaToken.address,
+          identifierOrCriteria: "0",
+          itemType: ItemType.ERC20,
+          transactionMethods: approvalAction.transactionMethods,
+          operator: seaport.contract.address,
+        });
+
+        await approvalAction.transactionMethods.transact();
+        expect(
+          await wboaToken.allowance(fulfiller.address, seaport.contract.address)
+        ).to.eq(MAX_INT);
+
+        const fulfillAction = actions[1];
+        expect(fulfillAction).to.be.deep.equal({
+          type: "exchange",
+          transactionMethods: fulfillAction.transactionMethods,
+        });
+
+        const transaction = await fulfillAction.transactionMethods.transact();
+        expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
+        const receipt = await transaction.wait();
+
+        const offererAssetTokenBalance = await assetToken.balanceOf(
+          offerer.address,
+          tokenId
+        );
+        const fulfillerAssetTokenBalance = await assetToken.balanceOf(
+          fulfiller.address,
+          tokenId
+        );
+        expect(offererAssetTokenBalance).eq(BigNumber.from(2));
+        expect(fulfillerAssetTokenBalance).eq(BigNumber.from(98));
+
+        await verifyBalancesAfterFulfill({
+          ownerToTokenToIdentifierBalances,
+          order,
+          orderStatus,
+          unitsToFill: 2,
+          fulfillerAddress: fulfiller.address,
+          multicallProvider,
+          fulfillReceipt: receipt,
+        });
+
+        // Double check nft balances
+        expect(fulfillStandardOrderSpy).calledOnce;
+      });
+    });
+  }
+);

--- a/src/contracts/WBOA9.sol
+++ b/src/contracts/WBOA9.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.4.18;
+
+import "seaport/contracts/wboa/WBOA9.sol";


### PR DESCRIPTION
이 PR은 `seaport-js` SDK를 이용하여 WBOA 토큰과 AssetContractShared 토큰을 거래하는 예제코드입니다. 예제 상의 거래는 Seaport과 SharedStorefrontLazyMintAdapter 컨트랙트를 통해서 일어나고, 구매자의 의한 오퍼로 시작되는 거래입니다.

추가적으로 다음의 코드를 작성할 예정입니다.
- 판매자에 의한 리스팅이고, WBOA와 AssetContractShared의 교환
- 판매자에 의한 리스팅이고, BOA와 AssetContractShared의 교환
