### PR TITLE
트랜잭션 데이터의 도메인명 변경

### DIFF
--- a/src/__tests__/boaspace/basic-fulfill.spec.ts
+++ b/src/__tests__/boaspace/basic-fulfill.spec.ts
@@ -41,8 +41,8 @@ describeWithFixture(
     const erc1155Amount2 = "7";
     const assetTokenAmount = "10";
 
-    const OPENSEA_DOMAIN = "opensea.io";
-    const OPENSEA_TAG = "360c6ebe";
+    const BOASPACE_DOMAIN = "boaspace.io";
+    const BOASPACE_TAG = "7f688786";
 
     const ZeroAddress = "0x0000000000000000000000000000000000000000";
 
@@ -265,7 +265,7 @@ describeWithFixture(
             { order: fourthOrder },
           ],
           accountAddress: fulfiller.address,
-          domain: OPENSEA_DOMAIN,
+          domain: BOASPACE_DOMAIN,
         });
 
         const approvalAction = actions[0];
@@ -356,11 +356,11 @@ describeWithFixture(
           (
             await fulfillAction.transactionMethods.buildTransaction()
           ).data?.slice(-8)
-        ).to.eq(OPENSEA_TAG);
+        ).to.eq(BOASPACE_TAG);
 
         const transaction = await fulfillAction.transactionMethods.transact();
 
-        expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
+        expect(transaction.data.slice(-8)).to.eq(BOASPACE_TAG);
 
         const balances = await Promise.all([
           testErc1155.balanceOf(offerer.address, nftId),
@@ -539,7 +539,7 @@ describeWithFixture(
             { order: fourthOrder },
           ],
           accountAddress: fulfiller.address,
-          domain: OPENSEA_DOMAIN,
+          domain: BOASPACE_DOMAIN,
         });
 
         const approvalAction = actions[0];
@@ -622,11 +622,11 @@ describeWithFixture(
           (
             await fulfillAction.transactionMethods.buildTransaction()
           ).data?.slice(-8)
-        ).to.eq(OPENSEA_TAG);
+        ).to.eq(BOASPACE_TAG);
 
         const transaction = await fulfillAction.transactionMethods.transact();
 
-        expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
+        expect(transaction.data.slice(-8)).to.eq(BOASPACE_TAG);
 
         const balances = await Promise.all([
           testErc1155.balanceOf(offerer.address, nftId),

--- a/src/__tests__/boaspace/erc1155-wboa.fulfill.spec.ts
+++ b/src/__tests__/boaspace/erc1155-wboa.fulfill.spec.ts
@@ -34,8 +34,8 @@ describeWithFixture(
     let tokenId: BigNumber;
     const assetTokenAmount = "10";
 
-    const OPENSEA_DOMAIN = "opensea.io";
-    const OPENSEA_TAG = "360c6ebe";
+    const BOASPACE_DOMAIN = "boaspace.io";
+    const BOASPACE_TAG = "7f688786";
 
     const ZeroAddress = "0x0000000000000000000000000000000000000000";
 
@@ -50,6 +50,9 @@ describeWithFixture(
 
       [offerer, zone, fulfiller, admin] = await ethers.getSigners();
       multicallProvider = new providers.MulticallProvider(ethers.provider);
+
+      console.log("offerer:", offerer.address);
+      console.log("fulfiller:", fulfiller.address);
 
       // Deploy AssetContractShared contract
       const name = "BOASPACE Collections";
@@ -181,7 +184,7 @@ describeWithFixture(
           order,
           unitsToFill: 2,
           accountAddress: fulfiller.address,
-          domain: OPENSEA_DOMAIN,
+          domain: BOASPACE_DOMAIN,
         });
 
         // approve to SharedStorefrontLazyMintAdapter
@@ -218,7 +221,7 @@ describeWithFixture(
         });
 
         const transaction = await fulfillAction.transactionMethods.transact();
-        expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
+        expect(transaction.data.slice(-8)).to.eq(BOASPACE_TAG);
         const receipt = await transaction.wait();
 
         const offererAssetTokenBalance = await assetToken.balanceOf(


### PR DESCRIPTION
원래 `seaport-js`에서는 모든 트랙잭션의  데이터에 `opensea.io` 스트링에 해당하는 태그를 붙여서 사용하는데, BoaSpace 프로젝트에 맞는 태그로 변경합니다. 도메인 태그를 사용하는 이유는 블록 익스플로러에서 트랙잭션을 구분하는 용도로 쓰이는 것으로 보입니다. 참고로 EVM에서 파라미터 이외의 데이터는 무시하는 것으로 보입니다.

[관련한 stackexchange 질문](https://ethereum.stackexchange.com/questions/47876/is-it-legal-to-include-arbitrary-bytes-at-the-end-of-the-data-section-executing).