### PR TITLE
npm 등록을 위한 패키지명 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@boaspace/seaport-js",
+  "name": "boa-space-seaport-js",
   "version": "1.0.0",
   "description": "[BoaSpace Contracts](https://github.com/bosagora/boa-space-contracts) is a new marketplace protocol for safely and efficiently buying and selling NFTs. This is a JavaScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",


### PR DESCRIPTION
이전에 패키지명이 `@boaspace/seaport-js`으로 되어 있어서 `npm publish`할 때 문제가 발생하는 것으로 보이므로, 리파지토리명과 동일하게 `boa-space-seaport-js`로 변경해서 사용하도록 하겠습니다.

이전에 `npm publish --access=public`명령에 대해서 발생한 에러는 다음과 같습니다.
```
npm ERR! code E404
npm ERR! 404 Not Found - PUT https://registry.npmjs.org/@boaspace%2fseaport-js - Scope not found
npm ERR! 404
npm ERR! 404  ‘@boaspace/seaport-js@1.0.0’ is not in this registry.
```